### PR TITLE
Fix high CPU usage on windows

### DIFF
--- a/include/envoy/network/transport_socket.h
+++ b/include/envoy/network/transport_socket.h
@@ -71,6 +71,9 @@ public:
    * @param event supplies the connection event
    */
   virtual void raiseEvent(ConnectionEvent event) PURE;
+
+  virtual void unsetFileReadyType(uint32_t type) PURE;
+  virtual void updateFileReadyType(uint32_t type) PURE;
 };
 
 /**

--- a/source/common/network/raw_buffer_socket.h
+++ b/source/common/network/raw_buffer_socket.h
@@ -2,7 +2,7 @@
 
 #include "envoy/buffer/buffer.h"
 #include "envoy/network/transport_socket.h"
-
+#include "envoy/event/file_event.h"
 #include "common/common/logger.h"
 
 namespace Envoy {


### PR DESCRIPTION
*Description*:Windows uses Event::FileTriggerType::Level. Envoy always enables EV_WRITE events. This creates a busy wait resulting in high CPU.
So set FileReadyType::Write only when send returns EAGAIN or EWOULDBLOCK.
TODO: This requires cleanup to keep these changes specific to Windows only (not linux).
*Risk Level*:Med
*Testing*:
*Docs Changes*:
*Release Notes*:
[Optional Fixes #Issue]
[Optional *Deprecated*:]
